### PR TITLE
lodash tree-shaking

### DIFF
--- a/src/VueChartwerkBaseMixin.ts
+++ b/src/VueChartwerkBaseMixin.ts
@@ -1,4 +1,4 @@
-import * as _ from 'lodash';
+import has from 'lodash/has';
 
 export default {
   props: {
@@ -42,19 +42,19 @@ export default {
       if(this.options.eventsCallbacks === undefined) {
         this.options.eventsCallbacks = {}
       }
-      if(_.has(this.$listeners, 'zoomIn')) {
+      if(has(this.$listeners, 'zoomIn')) {
         this.options.eventsCallbacks.zoomIn = this.zoomIn.bind(this);
       }
-      if(_.has(this.$listeners, 'zoomOut')) {
+      if(has(this.$listeners, 'zoomOut')) {
         this.options.eventsCallbacks.zoomOut = this.zoomOut.bind(this);
       }
-      if(_.has(this.$listeners, 'mouseMove')) {
+      if(has(this.$listeners, 'mouseMove')) {
         this.options.eventsCallbacks.mouseMove = this.mouseMove.bind(this);
       }
-      if(_.has(this.$listeners, 'mouseOut')) {
+      if(has(this.$listeners, 'mouseOut')) {
         this.options.eventsCallbacks.mouseOut = this.mouseOut.bind(this);
       }
-      if(_.has(this.$listeners, 'onLegendClick')) {
+      if(has(this.$listeners, 'onLegendClick')) {
         this.options.eventsCallbacks.onLegendClick = this.onLegendClick.bind(this);
       }
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,18 @@ import { palette } from './colors';
 
 // we import only d3 types here
 import * as d3 from 'd3';
-import * as _ from 'lodash';
+
+import defaults from 'lodash/defaults';
+import includes from 'lodash/includes';
+import first from 'lodash/first';
+import last from 'lodash/last';
+import mergeWith from 'lodash/mergeWith';
+import min from 'lodash/min';
+import minBy from 'lodash/minBy';
+import max from 'lodash/max';
+import maxBy from 'lodash/maxBy';
+import add from 'lodash/add';
+import replace from 'lodash/replace'
 
 
 const DEFAULT_MARGIN: Margin = { top: 30, right: 20, bottom: 20, left: 30 };
@@ -54,7 +65,7 @@ abstract class ChartwerkBase<T extends TimeSerie, O extends Options> {
     // TODO: test if it's necessary
     styles.use();
 
-    _.defaults(this._options, DEFAULT_OPTIONS);
+    defaults(this._options, DEFAULT_OPTIONS);
     this._d3Node = this._d3.select(el);
   }
 
@@ -264,7 +275,7 @@ abstract class ChartwerkBase<T extends TimeSerie, O extends Options> {
         .append('g')
         .attr('class', 'legend-row');
       for(let idx = 0; idx < this._series.length; idx++) {
-        if(_.includes(this.seriesTargetsWithBounds, this._series[idx].target)) {
+        if(includes(this.seriesTargetsWithBounds, this._series[idx].target)) {
           continue;
         }
         let node = legendRow.selectAll('text').node();
@@ -441,8 +452,8 @@ abstract class ChartwerkBase<T extends TimeSerie, O extends Options> {
     // TODO: add timezone (utc / browser) to options and use it
     return this._d3.scaleTime()
       .domain([
-        new Date(_.first(this._series[0].datapoints)[1]),
-        new Date(_.last(this._series[0].datapoints)[1])
+        new Date(first(this._series[0].datapoints)[1]),
+        new Date(last(this._series[0].datapoints)[1])
       ])
       .range([0, this.width]);
   }
@@ -450,8 +461,8 @@ abstract class ChartwerkBase<T extends TimeSerie, O extends Options> {
   get timestampScale(): d3.ScaleLinear<number, number> {
     return this._d3.scaleLinear()
       .domain([
-        _.first(this._series[0].datapoints)[1],
-        _.last(this._series[0].datapoints)[1]
+        first(this._series[0].datapoints)[1],
+        last(this._series[0].datapoints)[1]
       ])
       .range([0, this.width])
   }
@@ -520,8 +531,8 @@ abstract class ChartwerkBase<T extends TimeSerie, O extends Options> {
     if(this._series.length === 0) {
       return undefined;
     }
-    const startTimestamp = _.first(this._series[0].datapoints)[1];
-    const endTimestamp = _.last(this._series[0].datapoints)[1];
+    const startTimestamp = first(this._series[0].datapoints)[1];
+    const endTimestamp = last(this._series[0].datapoints)[1];
     return (endTimestamp - startTimestamp) / 1000;
   }
 
@@ -606,15 +617,15 @@ abstract class ChartwerkBase<T extends TimeSerie, O extends Options> {
     if(this._options.margin !== undefined) {
       return this._options.margin;
     }
-    return _.mergeWith({}, DEFAULT_MARGIN, this.extraMargin, _.add);
+    return mergeWith({}, DEFAULT_MARGIN, this.extraMargin, add);
   }
 
   get minValue(): number | undefined {
-    const minValue = _.min(
+    const minValue = min(
       this._series
         .filter(serie => serie.visible !== false)
         .map(
-          serie => _.minBy<number[]>(serie.datapoints, dp => dp[0])[0]
+          serie => minBy<number[]>(serie.datapoints, dp => dp[0])[0]
         )
     );
 
@@ -625,11 +636,11 @@ abstract class ChartwerkBase<T extends TimeSerie, O extends Options> {
   }
 
   get maxValue(): number | undefined {
-    const maxValue = _.max(
+    const maxValue = max(
       this._series
         .filter(serie => serie.visible !== false)
         .map(
-          serie => _.maxBy<number[]>(serie.datapoints, dp => dp[0])[0]
+          serie => maxBy<number[]>(serie.datapoints, dp => dp[0])[0]
         )
     );
 
@@ -640,7 +651,7 @@ abstract class ChartwerkBase<T extends TimeSerie, O extends Options> {
   }
 
   formatedBound(alias: string, target: string): string {
-    const confidenceMetric = _.replace(alias, '$__metric_name', target);
+    const confidenceMetric = replace(alias, '$__metric_name', target);
     return confidenceMetric;
   }
 


### PR DESCRIPTION
This PR applies lodash [tree-shaking](https://developers.google.com/web/fundamentals/performance/optimizing-javascript/tree-shaking/) which:
- reduces bundle size
- resolves the `_` hoisting problem when importing `@chartwerk/base` as lib

Changes:
- use separate functions import from lodash instead of `import * as _ from lodash`